### PR TITLE
[bug]Docker pull fails with HTTP 408

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,7 @@ Vagrant.configure("2") do |config|
                       inline: <<-SCRIPT
     sudo mv /tmp/form3.crt /usr/local/share/ca-certificates/form3_ca.crt
     sudo update-ca-certificates
+    sudo ip link set dev $(ip a|grep -E "^[0-9]*:" | grep -v LOOPBACK|awk -F: '{print $2}' |grep -v docker) mtu 1024
   SCRIPT
 
   config.vm.provision :docker


### PR DESCRIPTION
When starting the vagrant on my Mac M1, it fails with :
`f3-interview: Error response from daemon: error parsing HTTP 408 response body: invalid character '<' looking for beginning of value: "<html><body><h1>408 Request Time-out</h1>\nYour browser didn't send a complete request in time.\n</body></html>\n"`

The VM is not able to pull images from DockerHub.
From [DockerHub Forum](https://forums.docker.com/t/http-408-request-time-out-but-not-a-ratelimit-or-dns-issue/113755) the problem is due to a too high MTU.

After applying the patch from this PR, I do not have the issue anymore.