### PR TITLE
Changed the submission guidance to be less ambigious

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ We would like you to complete the following tasks:
 ## Submission Guidance
 
 ### Shoulds
-- Only use plain Terraform in your solution
+- Use only plain Terraform in your solution, i.e. anything supported by the Terraform CLI installed by the `run.sh` script, but not external tooling or libraries that wrap or extend Terraform, such as Terragrunt or tfenv
 - Only modify files in the `tf/` directory, `run.sh`, and `docker-compose.yml`
 - Keep the current versions of the services running in `development` and `production` environments
 - Structure your code in a way that will segregate environments
@@ -121,4 +121,4 @@ We would like you to complete the following tasks:
 - Structure your code in a way that allows engineers to run different versions of services in different environments
 
 ### Should Nots
-- Use tools that extend Terraform such as Terragrunt
+- Do not use external tools that extend Terraform, such as Terragrunt.


### PR DESCRIPTION
This Pull Request updates the instructions of our platform test exercise to clarify the usage of "plain Terraform".

Previously, the term "plain Terraform" caused confusion among candidates regarding the scope of Terraform's features they were allowed to use.  

This amendment is intended to eliminate ambiguity.